### PR TITLE
Adiciona arquivos de resultado do Karate ao gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+
+*target/


### PR DESCRIPTION
Toda a pasta de target que contém os resultados do teste foi adicionada no gitignore